### PR TITLE
Require polycyclic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 /doc/*.six
 /doc/*.tex
 /doc/*.toc
+/doc/_*.xml
+/doc/QuickCheck.xml
+/doc/title.xml
 /doc/manual.pdf
 
 /bin/

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -64,7 +64,7 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := ">= 4.9",
-  NeededOtherPackages := [ ],
+  NeededOtherPackages := [ ["polycyclic", ">=1.1"] ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],
 ),


### PR DESCRIPTION
`IsFreeAbelian` comes from the polycyclic package, but I didn't have this loaded which meant that QuickCheck wasn't working properly for me. I've possibly picked a too-old version.

Also updated `.gitignore` to ignore more autogenerated documentation files.