### PR TITLE
Use the GitHub repository for the `PackageWWWHome`, for now

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -29,10 +29,10 @@ Persons := [
 
 SourceRepository := rec(
     Type := "git",
-    URL := "https://github.com/gap-packages/QuickCheck",
+    URL := "https://github.com/ChrisJefferson/QuickCheck",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://gap-packages.github.io/QuickCheck/",
+PackageWWWHome  := ~.SourceRepository.URL,
 PackageInfoURL  := Concatenation( ~.PackageWWWHome, "PackageInfo.g" ),
 README_URL      := Concatenation( ~.PackageWWWHome, "README.md" ),
 ArchiveURL      := Concatenation( ~.SourceRepository.URL,


### PR DESCRIPTION
Since a `*.github.io/QuickCheck` URL doesn't yet exist, and also this repo is at `ChrisJefferson/QuickCheck`, not `gap-packages/QuickCheck`.