### PR TITLE
Allow `QC_ListOf` and `QC_SetOf` to create empty things

### DIFF
--- a/examples/using.autodoc
+++ b/examples/using.autodoc
@@ -83,8 +83,8 @@ The currently allowed argument types for QuickCheck are:
 
 There are also ways of defining lists or sets of arguments, recursively:
 
-* QC_ListOf(x) : A list of items of type x
-* QC_SetOf(x) : A set of items of type x
+* QC_ListOf(x) : A (possibly empty) list of items of type x
+* QC_SetOf(x) : A (possibly empty) set of items of type x
 * QC_PairOf(x) : A pair of items of type x
 * QC_FixedLengthListOf(x, len) : A list of length len of items of type x
 

--- a/gap/generators.g
+++ b/gap/generators.g
@@ -29,7 +29,7 @@ end);
 
 QC_ListOf := function(object)
     return function(rg, limit)
-        return List([1..Random([1..limit])], {x} -> QC_MakeRandomArgument(object, rg, limit));
+        return List([1..Random([0..limit])], {x} -> QC_MakeRandomArgument(object, rg, limit));
     end;
 end;
 
@@ -45,7 +45,7 @@ QC_PairOf := {o} -> QC_FixedLengthListOf(o, 2);
 QC_SetOf := function(object)
     return function(rg, limit)
         local set, targetsize, testlimit;
-        targetsize := Random([1..limit]);
+        targetsize := Random([0..limit]);
         set := [];
         # In case we have trouble filling the set, put a limit on number of tests
         testlimit := targetsize * limit + 10;

--- a/tst/tst-gap/lists/empty.tst
+++ b/tst/tst-gap/lists/empty.tst
@@ -1,0 +1,4 @@
+gap> QC_ListOf(IsPosInt)(GlobalRandomSource, 0) = [];
+true
+gap> QC_SetOf(IsPosInt)(GlobalRandomSource, 0) = [];
+true


### PR DESCRIPTION
I think this is sensible, since empty lists and sets are things that can come up!

Perhaps it might be useful to have `QC_NonemptyListOf` and `QC_NonemptySetOf` if this causes problems for users?